### PR TITLE
Create psake builds with code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+[Bb]uild/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
@@ -135,6 +136,10 @@ _TeamCity*
 # Visual Studio code coverage results
 *.coverage
 *.coveragexml
+
+# Coverlet code coverage results
+coverage.json
+coverage.opencover.xml
 
 # NCrunch
 _NCrunch_*

--- a/integration-build.ps1
+++ b/integration-build.ps1
@@ -1,0 +1,2 @@
+. .\scripts\bootstrap.ps1
+invoke-psake -buildFile .\scripts\psake-build.ps1 -taskList Integration.Build

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,0 +1,79 @@
+function TryLoad-Psake($path) {
+
+    $toNatural = { [regex]::Replace($_, '\d+', { $args[0].Value.PadLeft(20) }) }
+
+    $psakePath = `
+        get-childitem $path\psake*\psake.psm1 `
+            -ErrorAction SilentlyContinue -Recurse `
+        | Sort-Object $toNatural | select-object -last 1
+
+        if ($psakePath -eq $null) {
+        Write-Output "[x] Psake not found within $path"
+    } else {
+        import-module $psakePath
+    }
+}
+
+function TryLoad-Psake-ViaNuGetCache()
+{
+    $locals = $null
+
+    $nuget = get-command nuget -ErrorAction SilentlyContinue
+    $dotnet = get-command dotnet -ErrorAction SilentlyContinue
+
+    if ($nuget -ne $null) {
+        # nuget returns a list of the form "label : folder"
+        Write-Output "[-] Finding NuGet caches via nuget.exe"
+        $locals = & $nuget locals all -list
+    } elseif ($dotnet -ne $null) {
+        # dotnet returns a list of the form "info : label : folder"
+        # So we strip "info : " from the start of each line
+        Write-Output "[-] Finding NuGet caches via dotnet.exe"
+        $locals = & $dotnet nuget locals all --list | % { $_.SubString(7) }
+    }
+
+    foreach($local in $locals)
+    {
+        $index = $local.IndexOf(":")
+        $folder = $local.Substring($index + 1).Trim()
+        TryLoad-Psake $folder
+    }
+}
+
+if ((get-module psake) -eq $null) {
+    TryLoad-Psake .\lib\psake
+}
+
+if ((get-module psake) -eq $null) {
+    # Don't have psake loaded, try to load it from PowerShell's default module location
+    import-module psake -ErrorAction SilentlyContinue
+}
+
+if ((get-module psake) -eq $null) {
+    # Not yet loaded, try to load it from the packages folder
+    TryLoad-Psake ".\packages\"
+}
+
+if ((get-module psake) -eq $null) {
+    # Not yet loaded, try to load it from the chocolatey installation library
+    TryLoad-Psake $env:ProgramData\chocolatey\lib
+}
+
+$env:DOTNET_PRINT_TELEMETRY_MESSAGE = "false"
+
+if ((get-module psake) -eq $null) {
+    # Still not loaded, let's look in the various NuGet caches
+    TryLoad-Psake-ViaNuGetCache
+}
+
+$psake = get-module psake
+if ($psake -ne $null) {
+    $psakePath = $psake.Path
+    Write-Output "[+] Psake loaded from $psakePath"
+}
+else {
+    Write-Output "[!]"
+    Write-Output "[!] ***** Unable to load PSake *****"
+    Write-Output "[!]"
+    throw "PSake not loaded"
+}

--- a/scripts/psake-build.ps1
+++ b/scripts/psake-build.ps1
@@ -87,7 +87,9 @@ formatTaskName {
     }
 
     $divider = "=" * $width
-    return "`r`n$divider`r`n  $taskName`r`n$divider`r`n"
+    $now = get-date -format "HH:mm:ss"
+    $spacer = " " * ( $width - $taskName.Length - 14 )
+    return "`r`n$divider`r`n  $taskName $spacer $now`r`n$divider`r`n"
 } 
 
 function Write-SubtaskName($subtaskName) {

--- a/scripts/psake-build.ps1
+++ b/scripts/psake-build.ps1
@@ -1,0 +1,104 @@
+##
+## Psake build for the WordTutor
+##
+
+properties {
+    $baseDir = resolve-path ..\
+    $scriptsDir = resolve-path $baseDir\scripts
+    $srcDir = resolve-path $baseDir\src
+    $testsDir = resolve-path $baseDir\tests
+}
+
+# Do our integration build 
+Task Integration.Build -Depends Clean.SourceFolder, Unit.Tests
+
+## --------------------------------------------------------------------------------
+##   Prerequisite Targets
+## --------------------------------------------------------------------------------
+## Tasks used to ensure that prerequisites are available when needed. 
+
+Task Requires.DotNetExe {
+    $script:dotnetExe = (get-command dotnet -ErrorAction SilentlyContinue).Path
+
+    if ($dotnetExe -eq $null) {
+        $script:dotnetExe = resolve-path $env:ProgramFiles\dotnet\dotnet.exe -ErrorAction SilentlyContinue
+    }
+
+    if ($dotnetExe -eq $null) {
+        throw "Failed to find dotnet.exe"
+    }
+
+    Write-Output "Dotnet executable: $dotnetExe"
+}
+
+## --------------------------------------------------------------------------------
+##   Cleaning Targets
+## --------------------------------------------------------------------------------
+## Tasks used to clean up 
+
+Task Clean.SourceFolder {
+
+    Write-Info "Cleaning $srcDir"
+    remove-item $srcDir\*\bin\* -recurse -ErrorAction SilentlyContinue
+    remove-item $srcDir\*\obj\* -recurse -ErrorAction SilentlyContinue
+    remove-item $srcDir\*\publish\* -recurse -ErrorAction SilentlyContinue
+
+    Write-Info "Cleaning $testsDir"
+    remove-item $testsDir\*\bin\* -recurse -ErrorAction SilentlyContinue
+    remove-item $testsDir\*\obj\* -recurse -ErrorAction SilentlyContinue
+    remove-item $testsDir\*\publish\* -recurse -ErrorAction SilentlyContinue
+}
+
+## --------------------------------------------------------------------------------
+##   Build Targets
+## --------------------------------------------------------------------------------
+## Tasks used to perform steps of the actual build
+
+Task Compile -Depends Requires.DotNetExe {
+    
+    $solution = resolve-path $baseDir\*.sln
+    Write-Info "Solution is $solution"
+    Write-Host
+
+    & $dotNetExe build $solution
+}
+
+Task Unit.Tests -Depends Requires.DotNetExe, Compile {
+
+    foreach ($project in (resolve-path $testsDir\*\*.csproj)) {
+        $projectName = split-path $project -Leaf
+        Write-SubtaskName $projectName
+        exec {
+            & $dotnetExe test $project --no-build
+        }
+    }
+}
+
+## --------------------------------------------------------------------------------
+##   Support Functions
+## --------------------------------------------------------------------------------
+
+formatTaskName { 
+    param($taskName) 
+
+    $width = (get-host).UI.RawUI.WindowSize.Width - 2
+    if ($width -eq $null -or $width -gt 100) {
+        $width = 100
+    }
+
+    $divider = "=" * $width
+    return "`r`n$divider`r`n  $taskName`r`n$divider`r`n"
+} 
+
+function Write-SubtaskName($subtaskName) {
+    $divider = "-" * ($subtaskName.Length + 4)
+    Write-Output "$divider`r`n  $subtaskName`r`n$divider`r`n"
+}
+
+function Write-Info($message) {
+    Write-Host "[*] $message"
+}
+
+function Write-Warning($message) {
+    Write-Host "[!] $message"
+}

--- a/scripts/psake-build.ps1
+++ b/scripts/psake-build.ps1
@@ -66,10 +66,10 @@ Task Compile -Depends Requires.DotNetExe {
 Task Unit.Tests -Depends Requires.DotNetExe, Compile {
 
     foreach ($project in (resolve-path $testsDir\*\*.csproj)) {
-        $projectName = split-path $project -Leaf
+        $projectName = (get-item $project).BaseName
         Write-SubtaskName $projectName
         exec {
-            & $dotnetExe test $project --no-build
+            & $dotnetExe test $project /p:CollectCoverage=true /p:Exclude="[xunit*]*%2c[*.Tests]*"
         }
     }
 }

--- a/scripts/psake-build.ps1
+++ b/scripts/psake-build.ps1
@@ -10,7 +10,7 @@ properties {
 }
 
 # Do our integration build 
-Task Integration.Build -Depends Clean.SourceFolder, Unit.Tests
+Task Integration.Build -Depends Clean.BuildDir, Clean.SourceDir, Compile, Unit.Tests, Coverage.Report
 
 ## --------------------------------------------------------------------------------
 ##   Prerequisite Targets
@@ -31,12 +31,49 @@ Task Requires.DotNetExe {
     Write-Output "Dotnet executable: $dotnetExe"
 }
 
+Task Requires.ReportGenerator -Depends Requires.DotNetExe {
+
+    $toNatural = { [regex]::Replace($_, '\d+', { $args[0].Value.PadLeft(20) }) }
+
+    # dotnet returns a list of the form "info : label : folder"
+    # So we strip "info : " from the start of each line
+    Write-Output "[-] Finding NuGet caches via dotnet.exe"
+    $locals = & $dotnetExe nuget locals all --list | % { $_.SubString(7) }
+
+    foreach($local in $locals)
+    {
+        $index = $local.IndexOf(":")
+        $folder = $local.Substring($index + 1).Trim()
+
+        $exePath = `
+            get-childitem $folder\reportgenerator\*\ReportGenerator.exe `
+                -ErrorAction SilentlyContinue -Recurse `
+            | Sort-Object $toNatural | select-object -last 1
+
+        if ($exePath -ne $null)
+        {
+            Write-Output "[+] ReportGenerator found at $exePath"
+            $script:reportGeneratorExe = $exePath
+            break
+        }
+        else 
+        {
+            Write-Output "[x] ReportGenerator not found within $folder"
+        }
+    }
+
+    if ($reportGeneratorExe -eq $null)
+    {
+        throw "Failed to find ReportGenerator.exe"
+    }
+}
+
 ## --------------------------------------------------------------------------------
 ##   Cleaning Targets
 ## --------------------------------------------------------------------------------
 ## Tasks used to clean up 
 
-Task Clean.SourceFolder {
+Task Clean.SourceDir {
 
     Write-Info "Cleaning $srcDir"
     remove-item $srcDir\*\bin\* -recurse -ErrorAction SilentlyContinue
@@ -47,6 +84,31 @@ Task Clean.SourceFolder {
     remove-item $testsDir\*\bin\* -recurse -ErrorAction SilentlyContinue
     remove-item $testsDir\*\obj\* -recurse -ErrorAction SilentlyContinue
     remove-item $testsDir\*\publish\* -recurse -ErrorAction SilentlyContinue
+}
+
+Task Clean.BuildDir {
+
+    $script:buildDir = join-path $baseDir "build"
+
+    Write-Host "Build output folder: $buildDir"
+
+    if (test-path $buildDir) {
+        remove-item $buildDir -recurse -force -ErrorAction SilentlyContinue
+    }
+
+    mkdir $buildDir -ErrorAction SilentlyContinue | Out-Null
+}
+
+Task Clean.CoverageReportDir -Depends Clean.BuildDir {
+
+    $script:coverageReportDir = join-path $buildDir coverage
+    Write-Host "Coverage report folder: $coverageReportDir"
+
+    if (test-path $coverageReportDir) {
+        remove-item $coverageReportDir -recurse -force -ErrorAction SilentlyContinue
+    }
+
+    mkdir $coverageReportDir -ErrorAction SilentlyContinue | Out-Null
 }
 
 ## --------------------------------------------------------------------------------
@@ -69,9 +131,19 @@ Task Unit.Tests -Depends Requires.DotNetExe, Compile {
         $projectName = (get-item $project).BaseName
         Write-SubtaskName $projectName
         exec {
-            & $dotnetExe test $project /p:CollectCoverage=true /p:Exclude="[xunit*]*%2c[*.Tests]*"
+            & $dotnetExe test $project /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[xunit*]*%2c[*.Tests]*"
         }
     }
+}
+
+Task Coverage.Report -Depends Requires.ReportGenerator, Clean.CoverageReportDir, Unit.Tests {
+
+    exec {
+        & $reportGeneratorExe -reports:$testsDir\*\*.opencover.xml -targetdir:$coverageReportDir
+    }
+
+    $openCoverIndex = resolve-path $coverageReportDir\index.htm
+    & $openCoverIndex
 }
 
 ## --------------------------------------------------------------------------------

--- a/tests/WordTutor.Core.Tests/VocabularyWordTests.cs
+++ b/tests/WordTutor.Core.Tests/VocabularyWordTests.cs
@@ -6,14 +6,21 @@ namespace WordTutor.Core.Tests
 {
     public class VocabularyWordTests
     {
-        private readonly VocabularyWord _word = new VocabularyWord("sample")
-            .WithPhrase("alpha")
-            .WithPronunciation("beta");
+        private readonly string _spelling = "bogus";
+        private readonly string _phrase = "this is a bogus word.";
+        private readonly string _pronunciation = "boogus";
+
+        private readonly VocabularyWord _word;
+
+        public VocabularyWordTests()
+        {
+            _word = new VocabularyWord(_spelling)
+                .WithPhrase(_phrase)
+                .WithPronunciation(_pronunciation);
+        }
 
         public class Constructor : VocabularyWordTests
         {
-            private readonly string _spelling = "sample";
-
             [Fact]
             public void WithNullWord_ThrowsException()
             {
@@ -104,8 +111,6 @@ namespace WordTutor.Core.Tests
 
         public class WithPronunciation: VocabularyWordTests
         {
-            private readonly VocabularyWord _word = new VocabularyWord("sample");
-
             [Fact]
             public void WithNull_ThrowsException()
             {
@@ -133,8 +138,6 @@ namespace WordTutor.Core.Tests
 
         public class WithPhrase : VocabularyWordTests
         {
-            private readonly VocabularyWord _word = new VocabularyWord("sample");
-
             [Fact]
             public void WithNull_ThrowsException()
             {
@@ -162,19 +165,6 @@ namespace WordTutor.Core.Tests
 
         public class EqualsVocabularyWord : VocabularyWordTests
         {
-            private readonly string _spelling = "bogus";
-            private readonly string _phrase = "this is a bogus word.";
-            private readonly string _pronunciation = "boogus";
-
-            private readonly VocabularyWord _word;
-
-            public EqualsVocabularyWord()
-            {
-                _word = new VocabularyWord(_spelling)
-                    .WithPhrase(_phrase)
-                    .WithPronunciation(_pronunciation);
-            }
-
             [Fact]
             public void GivenNull_ReturnsFalse()
             {
@@ -222,19 +212,6 @@ namespace WordTutor.Core.Tests
 
         public class EqualsObject :VocabularyWordTests
         {
-            private readonly string _spelling = "bogus";
-            private readonly string _phrase = "this is a bogus word.";
-            private readonly string _pronunciation = "boogus";
-
-            private readonly VocabularyWord _word;
-
-            public EqualsObject()
-            {
-                _word = new VocabularyWord(_spelling)
-                    .WithPhrase(_phrase)
-                    .WithPronunciation(_pronunciation);
-            }
-
             [Fact]
             public void GivenNull_ReturnsFalse()
             {
@@ -267,19 +244,6 @@ namespace WordTutor.Core.Tests
 
         public class GetHashCodeMethod : VocabularyWordTests
         {
-            private readonly string _spelling = "bogus";
-            private readonly string _phrase = "this is a bogus word.";
-            private readonly string _pronunciation = "boogus";
-
-            private readonly VocabularyWord _word;
-
-            public GetHashCodeMethod()
-            {
-                _word = new VocabularyWord(_spelling)
-                    .WithPhrase(_phrase)
-                    .WithPronunciation(_pronunciation);
-            }
-
             [Fact]
             public void GivenSelf_ReturnsConsistentValue()
             {

--- a/tests/WordTutor.Core.Tests/WordTutor.Core.Tests.csproj
+++ b/tests/WordTutor.Core.Tests/WordTutor.Core.Tests.csproj
@@ -15,6 +15,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="ReportGenerator" Version="4.0.15" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/WordTutor.Core.Tests/WordTutor.Core.Tests.csproj
+++ b/tests/WordTutor.Core.Tests/WordTutor.Core.Tests.csproj
@@ -9,8 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Set up command line builds with [Psake](https://github.com/psake/psake), including coverage reporting with [coverlet](https://github.com/tonerdo/coverlet).

For a discussion of this code, see the associated blog post:
http://nichesoftware.co.nz/2019/03/30/wordtutor-psake-builds.html