### PR TITLE
Convention tests to enforce immutability of specific types

### DIFF
--- a/src/WordTutor.Core/ImmutableAttribute.cs
+++ b/src/WordTutor.Core/ImmutableAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WordTutor.Core
+{
+    /// <summary>
+    /// Marker attribute used to indicate that class instances are immutable
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class ImmutableAttribute : Attribute
+    {
+    }
+}

--- a/src/WordTutor.Core/ModifyVocabularyWordScreen.cs
+++ b/src/WordTutor.Core/ModifyVocabularyWordScreen.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace WordTutor.Core
 {
+    [Immutable]
     public sealed class ModifyVocabularyWordScreen : Screen, IEquatable<ModifyVocabularyWordScreen?>
     {
         private readonly static EqualityComparer<VocabularyWord> _wordComparer

--- a/src/WordTutor.Core/Screen.cs
+++ b/src/WordTutor.Core/Screen.cs
@@ -2,6 +2,7 @@
 
 namespace WordTutor.Core
 {
+    [Immutable]
     public abstract class Screen : IEquatable<Screen?>
     {
         public abstract bool Equals(Screen? other);

--- a/src/WordTutor.Core/VocabularyBrowserScreen.cs
+++ b/src/WordTutor.Core/VocabularyBrowserScreen.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 
 namespace WordTutor.Core
 {
-    public class VocabularyBrowserScreen : Screen, IEquatable<VocabularyBrowserScreen>
+    [Immutable]
+    public sealed class VocabularyBrowserScreen : Screen, IEquatable<VocabularyBrowserScreen>
     {
         private static readonly EqualityComparer<VocabularyWord> _selectionComparer
             = EqualityComparer<VocabularyWord>.Default;

--- a/src/WordTutor.Core/VocabularySet.cs
+++ b/src/WordTutor.Core/VocabularySet.cs
@@ -9,6 +9,7 @@ namespace WordTutor.Core
     /// <summary>
     /// A set of words that make up a vocabulary for spelling drills
     /// </summary>
+    [Immutable]
     public sealed class VocabularySet : IEquatable<VocabularySet>
     {
         private static readonly StringComparer _nameComparer = StringComparer.CurrentCulture;

--- a/src/WordTutor.Core/VocabularyWord.cs
+++ b/src/WordTutor.Core/VocabularyWord.cs
@@ -9,7 +9,7 @@ namespace WordTutor.Core
     // in order to satisfy the expanded type constraint IEquatable<VW?>
     [Immutable]
     [DebuggerDisplay("Word: '{Spelling}'")]
-    public class VocabularyWord : IEquatable<VocabularyWord?>
+    public sealed class VocabularyWord : IEquatable<VocabularyWord?>
     {
         /// <summary>
         /// Gets the word as correctly spelt

--- a/src/WordTutor.Core/VocabularyWord.cs
+++ b/src/WordTutor.Core/VocabularyWord.cs
@@ -7,7 +7,7 @@ namespace WordTutor.Core
     // If using a VocabularyWord? for a T where T : IEquatable<T>
     // then VW needs to implement IEquatable<VW?> 
     // in order to satisfy the expanded type constraint IEquatable<VW?>
-
+    [Immutable]
     [DebuggerDisplay("Word: '{Spelling}'")]
     public class VocabularyWord : IEquatable<VocabularyWord?>
     {

--- a/src/WordTutor.Core/WordTutorApplication.cs
+++ b/src/WordTutor.Core/WordTutorApplication.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace WordTutor.Core
 {
     [Immutable]
-    public class WordTutorApplication
+    public sealed class WordTutorApplication
     {
         // a stack of previously active screens
         private readonly ImmutableStack<Screen> _priorScreens;

--- a/src/WordTutor.Core/WordTutorApplication.cs
+++ b/src/WordTutor.Core/WordTutorApplication.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 namespace WordTutor.Core
 {
+    [Immutable]
     public class WordTutorApplication
     {
         // a stack of previously active screens

--- a/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
+++ b/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
@@ -14,8 +14,16 @@ namespace WordTutor.Core.Tests.ConventionTests
         [MemberData(nameof(PropertiesOfImmutableTypesToTest))]
         public void PropertiesOfImmutableTypesShouldHaveImmutableTypes(PropertyInfo property)
         {
-            property.PropertyType.IsImmutableType()
-                .Should().BeTrue($"property {property.Name} should be declared as an immutable type");
+            property.PropertyType.IsImmutableType().Should().BeTrue(
+                $"property {property.Name} should be declared as an immutable type");
+        }
+
+        [Theory]
+        [MemberData(nameof(PropertiesOfImmutableTypesToTest))]
+        public void PropertiesOfImmutableTypesMustNotBeWritable(PropertyInfo property)
+        {
+            property.CanWrite.Should().BeFalse(
+                $"property {property.Name} of immutable type {property.DeclaringType!.Name} should not be writable");
         }
 
         public static IEnumerable<object[]> PropertiesOfImmutableTypesToTest()

--- a/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
+++ b/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +11,7 @@ namespace WordTutor.Core.Tests.ConventionTests
     public class ImmutabilityTests
     {
         [Theory]
-        [MemberData(nameof(PropertiesOfImmutableTypesToTest))]
+        [MemberData(nameof(TestCasesArePropertiesOfImmutableTypes))]
         public void PropertiesOfImmutableTypesShouldHaveImmutableTypes(PropertyInfo property)
         {
             property.PropertyType.IsImmutableType().Should().BeTrue(
@@ -19,14 +19,30 @@ namespace WordTutor.Core.Tests.ConventionTests
         }
 
         [Theory]
-        [MemberData(nameof(PropertiesOfImmutableTypesToTest))]
+        [MemberData(nameof(TestCasesArePropertiesOfImmutableTypes))]
         public void PropertiesOfImmutableTypesMustNotBeWritable(PropertyInfo property)
         {
             property.CanWrite.Should().BeFalse(
                 $"property {property.Name} of immutable type {property.DeclaringType!.Name} should not be writable");
         }
 
-        public static IEnumerable<object[]> PropertiesOfImmutableTypesToTest()
+        [Theory]
+        [MemberData(nameof(TestCasesAreSubclassesOfImmutableTypes))]
+        public void SubTypesOfImmutableTypesMustBeImmutable(Type type)
+        {
+            type.IsImmutableType().Should().BeTrue(
+                $"Type {type.Name} should be marked [Immutable] because it descends from immutable type {type.BaseType.Name}.");
+        }
+
+        public static IEnumerable<object[]> TestCasesAreSubclassesOfImmutableTypes()
+        {
+            var immutableTypes = FindDeclaredImmutableTypes().ToHashSet();
+            return from t in typeof(WordTutorApplication).Assembly.GetTypes()
+                   where t.BaseType is Type && immutableTypes.Contains(t.BaseType)
+                   select new object[] { t };
+        }
+
+        public static IEnumerable<object[]> TestCasesArePropertiesOfImmutableTypes()
             => from t in FindDeclaredImmutableTypes()
                from p in t.GetProperties()
                select new object[] { p };

--- a/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
+++ b/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
@@ -34,6 +34,17 @@ namespace WordTutor.Core.Tests.ConventionTests
                 $"Type {type.Name} should be marked [Immutable] because it descends from immutable type {type.BaseType.Name}.");
         }
 
+        [Theory]
+        [MemberData(nameof(TestCasesAreImmutableTypes))]
+        public void ImmutableTypesShouldBeSealedOrAbstract(Type type)
+        {
+            type.Should().Match(t => t.IsAbstract || t.IsSealed);
+        }
+
+        public static IEnumerable<object[]> TestCasesAreImmutableTypes()
+            => from t in FindDeclaredImmutableTypes()
+               select new object[] { t };
+
         public static IEnumerable<object[]> TestCasesAreSubclassesOfImmutableTypes()
         {
             var immutableTypes = FindDeclaredImmutableTypes().ToHashSet();

--- a/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
+++ b/tests/WordTutor.Core.Tests/ConventionTests/ImmutabilityTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace WordTutor.Core.Tests.ConventionTests
+{
+    public class ImmutabilityTests
+    {
+        [Theory]
+        [MemberData(nameof(PropertiesOfImmutableTypesToTest))]
+        public void PropertiesOfImmutableTypesShouldHaveImmutableTypes(PropertyInfo property)
+        {
+            property.PropertyType.IsImmutableType()
+                .Should().BeTrue($"property {property.Name} should be declared as an immutable type");
+        }
+
+        public static IEnumerable<object[]> PropertiesOfImmutableTypesToTest()
+            => from t in FindDeclaredImmutableTypes()
+               from p in t.GetProperties()
+               select new object[] { p };
+
+        private static IEnumerable<Type> FindDeclaredImmutableTypes()
+            => from t in typeof(WordTutorApplication).Assembly.GetTypes()
+               where t.IsImmutableType()
+               select t;
+    }
+}

--- a/tests/WordTutor.Core.Tests/TypeExtensions.cs
+++ b/tests/WordTutor.Core.Tests/TypeExtensions.cs
@@ -8,7 +8,7 @@ namespace WordTutor.Core.Tests
 {
     public static class TypeExtensions
     {
-        private static HashSet<Type> _systemImmutableTypes 
+        private static HashSet<Type> _systemImmutableTypes
             = new HashSet<Type>
             {
                 typeof(int),
@@ -16,7 +16,7 @@ namespace WordTutor.Core.Tests
                 typeof(bool),
                 typeof(IImmutableSet<>)
             };
-        
+
         public static bool IsImmutableType(this Type type)
         {
             if (type is null)
@@ -24,7 +24,7 @@ namespace WordTutor.Core.Tests
                 return false;
             }
 
-            if (type.GetCustomAttribute<ImmutableAttribute>() is object)
+            if (type.GetCustomAttribute<ImmutableAttribute>(inherit: false) is object)
             {
                 return true;
             }
@@ -41,7 +41,7 @@ namespace WordTutor.Core.Tests
                 return definition.IsImmutableType()
                     && parameters.All(t => t.IsImmutableType());
             }
-            
+
             return false;
         }
     }

--- a/tests/WordTutor.Core.Tests/TypeExtensions.cs
+++ b/tests/WordTutor.Core.Tests/TypeExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+
+namespace WordTutor.Core.Tests
+{
+    public static class TypeExtensions
+    {
+        private static HashSet<Type> _systemImmutableTypes 
+            = new HashSet<Type>
+            {
+                typeof(int),
+                typeof(string),
+                typeof(bool),
+                typeof(IImmutableSet<>)
+            };
+        
+        public static bool IsImmutableType(this Type type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+
+            if (type.GetCustomAttribute<ImmutableAttribute>() is object)
+            {
+                return true;
+            }
+
+            if (_systemImmutableTypes.Contains(type))
+            {
+                return true;
+            }
+
+            if (type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                var definition = type.GetGenericTypeDefinition();
+                var parameters = type.GetGenericArguments();
+                return definition.IsImmutableType()
+                    && parameters.All(t => t.IsImmutableType());
+            }
+            
+            return false;
+        }
+    }
+}

--- a/tests/WordTutor.Core.Tests/TypeExtensionsTests.cs
+++ b/tests/WordTutor.Core.Tests/TypeExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Immutable;
+using System.Text;
+using Xunit;
+
+namespace WordTutor.Core.Tests
+{
+    public class TypeExtensionsTests
+    {
+        public class IsImmutableType: TypeExtensionsTests
+        {
+            [Theory]
+            [InlineData(typeof(VocabularyWord), true)]
+            [InlineData(typeof(string), true)]
+            [InlineData(typeof(StringBuilder), false)]
+            [InlineData(typeof(IImmutableSet<VocabularyWord>), true)]
+            [InlineData(typeof(IImmutableSet<StringBuilder>), false)]
+            public void GivenType_ReturnsExpectedResult(Type type, bool isImmutable)
+            {
+                var modifier = isImmutable ? "" : "not ";
+                type.IsImmutableType()
+                    .Should().Be(
+                        isImmutable,
+                        $"Type {type.Name} should {modifier} be immutable.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
For more information about the code in this PR, see the associated blog post http://nichesoftware.co.nz/2019/11/30/wordtutor-convention-testing.html